### PR TITLE
Remove the executable property to allow override.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -23,7 +23,6 @@ class Phpcs(Linter):
         r'severity="(?:(?P<error>error)|(?P<warning>warning))" '
         r'message="(?P<message>.*)" source'
     )
-    executable = 'phpcs'
     defaults = {
         '--standard=': 'PSR2',
     }
@@ -37,7 +36,7 @@ class Phpcs(Linter):
         if 'cmd' in settings:
             command = [settings.get('cmd')]
         else:
-            command = [self.executable_path]
+            command = ['phpcs']
 
         command.append('--report=checkstyle')
 


### PR DESCRIPTION
This problem was discussed here : SublimeLinter/SublimeLinter#455

If the `executable` property is defined, the plugin require the host system to have a global `phpcs` binary. If I haven't that binary installed (eg. I use composer to install inside my project folder) and I use the `*.sublime-project` file to configure my linter, the phpcs linter is never executed.

```
{
    "folders":
    [
        {
            "path": "."
        }
    ],
    "SublimeLinter": {
        "linters": {
            "phpcs": {
                "standard": "${folder}/phpcs.xml",
                "cmd": "${folder}/vendor/bin/phpcs"
            }
        }
    }
}
```

With that update suggested by @kaste the global binary is returned only if the configuration doesn't defined a specific one.